### PR TITLE
ci: add CI workflow for Rust unit and integration tests 🏗️

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  rust-tests:
+    name: Rust Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Unit tests
+        run: cargo test --lib --verbose
+
+      - name: Integration tests
+        run: cargo test --test integration --verbose


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yaml` with a `rust-tests` job
- Runs on push to `main` and on pull requests
- Uses `cargo test --lib` (4 unit tests) and `cargo test --test integration` (12 integration tests)
- Uses `dtolnay/rust-toolchain@stable` + `Swatinem/rust-cache@v2` for toolchain and caching
- Deliberately avoids bare `cargo test` — E2E tests require forge artifacts via `include_str!` at compile time

## Test plan

- [ ] Verify CI workflow triggers on this PR
- [ ] Verify all 4 unit tests pass in CI
- [ ] Verify all 12 integration tests pass in CI
- [ ] Verify bare `cargo test` is NOT used anywhere in the workflow

Closes #3
Part of #9