### PR TITLE
fix(test): update E2E tests for /auth/token endpoint 🧪

### DIFF
--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -339,7 +339,7 @@ async fn token_endpoint_returns_502_when_jwt_service_unreachable() {
         .await
         .expect("failed to grant access");
 
-    // Point jwt_service_url at a guaranteed-unreachable port
+    // Point jwt_service_url at a likely-unreachable port
     let dead_url = unreachable_url().await;
     let base_url = start_test_server(contract_address, Some(&dead_url)).await;
 


### PR DESCRIPTION
## Summary

- Fix `AuthConfig` compilation error in `tests/e2e.rs` (missing `jwt_service_url` field added in #14)
- Add `start_auth_server_with_jwt()` helper for tests needing jwt-auth-service URL
- Add `challenge_and_sign()` helper to reduce duplication across E2E tests
- Add 3 new E2E tests covering `/auth/token` endpoint behaviour

## Test plan

- [x] `cargo test --lib` — 4 unit tests pass
- [x] `cargo test --test integration` — 15 integration tests pass
- [x] `cargo test --test e2e` — 6 E2E tests compile and skip gracefully (no Autonity node)
- [x] `cargo test --test e2e --no-run` — compilation verified
- [ ] CI passes
- [ ] E2E tests pass with running Autonity node (manual verification)

Refs #17
