### PR TITLE
fix(nix): skip test compilation in Nix build 🔧

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,9 @@
             src = ./.;
             cargoLock.lockFile = ./Cargo.lock;
             nativeBuildInputs = [ rustToolchain ];
+            # Tests require Foundry artifacts (contracts/out/) which aren't
+            # available in the Nix sandbox. Tests run via CI, not Nix build.
+            doCheck = false;
           };
 
           alphaImage = n2c.buildImage {


### PR DESCRIPTION
## Summary

- Add `doCheck = false` to `buildRustPackage` in `flake.nix`
- E2E tests use `include_str!` to read Foundry artifacts (`contracts/out/`) which aren't available in the Nix sandbox
- Tests run via CI, not during Nix image builds

Refs #9

## Test plan

- [x] `nix build .#alpha-image` succeeds
- [x] Image pushed to `ghcr.io/klazomenai/keyra/alpha:latest`