### PR TITLE
fix(nix): use cargoTestFlags instead of doCheck = false 🔧

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,9 +29,9 @@
             src = ./.;
             cargoLock.lockFile = ./Cargo.lock;
             nativeBuildInputs = [ rustToolchain ];
-            # Tests require Foundry artifacts (contracts/out/) which aren't
-            # available in the Nix sandbox. Tests run via CI, not Nix build.
-            doCheck = false;
+            # E2E tests require Foundry artifacts (contracts/out/) which aren't
+            # available in the Nix sandbox. Run only core tests here; E2E tests run separately.
+            cargoTestFlags = [ "--lib" "--test" "integration" ];
           };
 
           alphaImage = n2c.buildImage {


### PR DESCRIPTION
## Summary

- Replace `doCheck = false` with `cargoTestFlags = [ "--lib" "--test" "integration" ]`
- Nix builds now run unit + integration tests in the sandbox, only skipping E2E tests that require Foundry artifacts (`contracts/out/`)
- PR #33 merged the original `doCheck = false` before this fix could be pushed

Refs #9

## Test plan

- [x] `nix build .#alpha` succeeds with tests running
- [ ] CI passes (unit + integration tests)
