### PR TITLE
ci: add Solidity Foundry test job 🏗️

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,3 +20,21 @@ jobs:
 
       - name: Integration tests
         run: cargo test --test integration --verbose
+
+  solidity-tests:
+    name: Solidity Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Forge build
+        working-directory: contracts
+        run: forge build
+
+      - name: Forge test
+        working-directory: contracts
+        run: forge test -vvv


### PR DESCRIPTION
## Summary

- Add `solidity-tests` job to CI workflow
- Checks out with `submodules: recursive` (forge-std is a git submodule)
- Runs `forge build` and `forge test -vvv` in `contracts/` directory
- Runs in parallel with existing `rust-tests` job (independent)

Refs #4

## Test plan

- [x] Solidity Tests job passes (all Foundry tests green)
- [x] Rust Tests job still passes (unchanged)
- [x] Forge-std submodule initialised correctly
