### PR TITLE
fix: make E2E tests fail-loud in CI instead of silently skipping 🐛

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -113,21 +113,31 @@ pub fn sign_message(signer: &PrivateKeySigner, message: &str) -> Vec<u8> {
 pub async fn require_node(rpc_url: &str) -> bool {
     let url: url::Url = match rpc_url.parse() {
         Ok(u) => u,
-        Err(_) => return false,
+        Err(e) => {
+            if std::env::var("CI").is_ok() {
+                panic!(
+                    "E2E test has invalid RPC URL '{}' (error: {e}). \
+                     In CI, this is a failure.",
+                    rpc_url
+                );
+            }
+            eprintln!("Skipping e2e test: invalid RPC URL '{}' (error: {})", rpc_url, e);
+            return false;
+        }
     };
     let provider = ProviderBuilder::new().connect_http(url);
 
     match provider.get_block_number().await {
         Ok(_) => true,
-        Err(_) => {
+        Err(e) => {
             if std::env::var("CI").is_ok() {
                 panic!(
-                    "E2E test requires EVM node at {} but it's not running. \
+                    "E2E test requires EVM node at {} but it's not running (error: {e}). \
                      In CI, this is a failure.",
                     rpc_url
                 );
             }
-            eprintln!("Skipping e2e test: EVM node not running at {}", rpc_url);
+            eprintln!("Skipping e2e test: EVM node not running at {} (error: {})", rpc_url, e);
             false
         }
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -104,8 +104,13 @@ pub fn sign_message(signer: &PrivateKeySigner, message: &str) -> Vec<u8> {
     sig.as_bytes().to_vec()
 }
 
-/// Check if Autonity node is running
-pub async fn is_node_running(rpc_url: &str) -> bool {
+/// Check if EVM node is running at the given URL.
+///
+/// In CI (`CI` env var set), panics if the node is unreachable — silent
+/// skips are false positives that defeat automated testing.
+///
+/// Locally, returns `false` so callers can skip gracefully.
+pub async fn require_node(rpc_url: &str) -> bool {
     let url: url::Url = match rpc_url.parse() {
         Ok(u) => u,
         Err(_) => return false,
@@ -114,6 +119,16 @@ pub async fn is_node_running(rpc_url: &str) -> bool {
 
     match provider.get_block_number().await {
         Ok(_) => true,
-        Err(_) => false,
+        Err(_) => {
+            if std::env::var("CI").is_ok() {
+                panic!(
+                    "E2E test requires EVM node at {} but it's not running. \
+                     In CI, this is a failure.",
+                    rpc_url
+                );
+            }
+            eprintln!("Skipping e2e test: EVM node not running at {}", rpc_url);
+            false
+        }
     }
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1,15 +1,15 @@
 //! End-to-end tests for the KeyRA authentication flow
 //!
-//! These tests require a running Autonity node in dev mode.
-//! Run with: `./scripts/start-autonity.sh` in a separate terminal.
+//! These tests require a running EVM node (Autonity dev mode or Anvil).
+//! Run with: `anvil --chain-id 1337` in a separate terminal.
 //!
-//! If no node is running, tests will be skipped.
+//! If no node is running, tests skip locally but panic in CI (CI=true).
 
 mod common;
 
 use alpha::auth::AuthConfig;
 use alloy::primitives::Address;
-use common::{deploy_access_contract, dev_wallet, grant_access, is_node_running, sign_message};
+use common::{deploy_access_contract, dev_wallet, grant_access, require_node, sign_message};
 use std::net::SocketAddr;
 use std::time::Duration;
 
@@ -104,9 +104,7 @@ async fn post_auth_token(
 /// 7. Access protected resource
 #[tokio::test]
 async fn full_auth_flow_with_access() {
-    // Check if node is running
-    if !is_node_running(RPC_URL).await {
-        eprintln!("Skipping e2e test: Autonity node not running at {}", RPC_URL);
+    if !require_node(RPC_URL).await {
         return;
     }
 
@@ -206,8 +204,7 @@ async fn full_auth_flow_with_access() {
 /// Test that access is denied when address is not in access list
 #[tokio::test]
 async fn access_denied_without_access() {
-    if !is_node_running(RPC_URL).await {
-        eprintln!("Skipping e2e test: Autonity node not running at {}", RPC_URL);
+    if !require_node(RPC_URL).await {
         return;
     }
 
@@ -264,8 +261,7 @@ async fn access_denied_without_access() {
 /// Test that invalid signatures are rejected
 #[tokio::test]
 async fn invalid_signature_rejected() {
-    if !is_node_running(RPC_URL).await {
-        eprintln!("Skipping e2e test: Autonity node not running at {}", RPC_URL);
+    if !require_node(RPC_URL).await {
         return;
     }
 
@@ -323,8 +319,7 @@ async fn invalid_signature_rejected() {
 /// The 502 proves all prior steps (SIWE verify, nonce, access check) passed.
 #[tokio::test]
 async fn token_endpoint_returns_502_when_jwt_service_unreachable() {
-    if !is_node_running(RPC_URL).await {
-        eprintln!("Skipping e2e test: Autonity node not running at {}", RPC_URL);
+    if !require_node(RPC_URL).await {
         return;
     }
 
@@ -360,8 +355,7 @@ async fn token_endpoint_returns_502_when_jwt_service_unreachable() {
 /// Test /auth/token returns 403 when address lacks access
 #[tokio::test]
 async fn token_endpoint_denied_without_access() {
-    if !is_node_running(RPC_URL).await {
-        eprintln!("Skipping e2e test: Autonity node not running at {}", RPC_URL);
+    if !require_node(RPC_URL).await {
         return;
     }
 


### PR DESCRIPTION
## Summary

- Replace `is_node_running` with `require_node` in `tests/common/mod.rs`
- In CI (`CI` env var set): panics if EVM node is unreachable — no more false positives
- Locally: skips gracefully (existing behaviour preserved)
- Applied to all 5 E2E test functions that check for a running node
- Updated module doc comment to reflect Anvil usage and CI behaviour

Refs #5

## Test plan

- [x] Unit + integration tests pass (15 tests)
- [x] E2E tests skip gracefully without node locally (`unset CI`)
- [x] E2E tests panic in CI mode without node (`CI=true`)
- [x] CI passes (Rust Tests + Solidity Tests)
